### PR TITLE
Small code de-duplications

### DIFF
--- a/include/nix/hdf5/DataSetHDF5.hpp
+++ b/include/nix/hdf5/DataSetHDF5.hpp
@@ -70,7 +70,6 @@ public:
 
     DataSpace getSpace() const;
 
-    bool isReferenced() const;
 };
 
 

--- a/include/nix/hdf5/H5Group.hpp
+++ b/include/nix/hdf5/H5Group.hpp
@@ -172,7 +172,6 @@ public:
      */
     bool removeAllLinks(const std::string &name);
 
-    bool isReferenced() const;
 
     virtual ~H5Group();
 

--- a/include/nix/hdf5/LocID.hpp
+++ b/include/nix/hdf5/LocID.hpp
@@ -40,6 +40,7 @@ public:
 
     void deleteLink(std::string name, hid_t plist = H5L_SAME_LOC);
 
+    unsigned int referenceCount() const;
 private:
 
     Attribute openAttr(const std::string &name) const;

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -523,11 +523,6 @@ void DataSet::write(const std::vector<Value> &values)
 
 }
 
-bool DataSet::isReferenced() const {
-    H5O_info_t oInfo;
-    H5Oget_info(hid, &oInfo);
-    return oInfo.rc > 0;
-}
 
 } // namespace hdf5
 } // namespace nix

--- a/src/hdf5/EntityHDF5.cpp
+++ b/src/hdf5/EntityHDF5.cpp
@@ -92,7 +92,7 @@ void EntityHDF5::forceCreatedAt(time_t t) {
 
 
 bool EntityHDF5::isValidEntity() {
-    return group().isReferenced();
+    return group().referenceCount() > 0;
 }
 
 

--- a/src/hdf5/H5Group.cpp
+++ b/src/hdf5/H5Group.cpp
@@ -368,12 +368,6 @@ boost::optional<DataSet> H5Group::findDataByNameOrAttribute(std::string const &a
     }
 }
 
-bool H5Group::isReferenced() const {
-    H5O_info_t oinfo;
-    H5Oget_info(hid, &oinfo);
-    return oinfo.rc > 0;
-}
-
 
 H5Group::~H5Group()
 {}

--- a/src/hdf5/LocID.cpp
+++ b/src/hdf5/LocID.cpp
@@ -53,6 +53,14 @@ void LocID::deleteLink(std::string name, hid_t plist) {
     HErr res = H5Ldelete(hid, name.c_str(), plist);
     res.check("LocIDL::deleteLink: Could not delete link: " + name);
 }
+
+
+unsigned int LocID::referenceCount() const {
+    H5O_info_t oInfo;
+    HErr res = H5Oget_info(hid, &oInfo);
+    res.check("LocID:referenceCount: Coud not get object info");
+    return oInfo.rc;
+}
 } // nix::hdf5
 
 } // nix::

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -234,7 +234,7 @@ void PropertyHDF5::values(const nix::none_t t) {
 
 
 bool PropertyHDF5::isValidEntity() {
-    return dataset().isReferenced();
+    return dataset().referenceCount() > 0;
 }
 
 


### PR DESCRIPTION
Ideally the referenceCount function should be at some `HObject` class, but for new `LocID` is good enough. I added some error checking too.
